### PR TITLE
Making valid length validator pass for no value

### DIFF
--- a/src/validators/valid-length.ts
+++ b/src/validators/valid-length.ts
@@ -32,7 +32,8 @@ export const validLength = (options: ValidLengthOptions) => {
     }
 
     return createValidator<string>(s =>
-        (options.min === undefined || s.length >= options.min) && (options.max === undefined || s.length <= options.max)
+        !s
+        || ((options.min === undefined || s.length >= options.min) && (options.max === undefined || s.length <= options.max))
         , getMessage(options)
     );
 };

--- a/test/validators/valid-length.test.ts
+++ b/test/validators/valid-length.test.ts
@@ -5,6 +5,23 @@ import { validLength } from "../../src/validators/valid-length";
 @TestFixture("ValidLength")
 export class ValidLengthTests {
 
+    @TestCase(null)
+    @TestCase(undefined)
+    @TestCase("")
+    @Test("should pass for null, undefined or empty")
+    public shouldPassForNullUndefinedOrEmpty(value: string) {
+        const message = "Invalid length";
+
+        const validator = validLength({
+            min: 3,
+            max: 5,
+            message
+        });
+
+        const results = validator(value);
+        Expect(results).toBeAPass();
+    }
+
     @TestCase(2, 10, "12345")
     @TestCase(5, undefined, "12345")
     @TestCase(undefined, 6, "123")


### PR DESCRIPTION
The validators should not fail if no value is provided.  If you need a field to be required you should combine these validators with the relevant required validator.

This will however be a breaking change